### PR TITLE
introduced ActivityExtractionParamSet

### DIFF
--- a/element_calcium_imaging/imaging.py
+++ b/element_calcium_imaging/imaging.py
@@ -184,9 +184,8 @@ class Processing(dj.Computed):
         return ProcessingTask & scan.ScanInfo
 
     def make(self, key):
-        task_mode = (ProcessingTask & key).fetch1('task_mode')
+        task_mode, output_dir = (ProcessingTask & key).fetch1('task_mode', 'processing_output_dir')
 
-        output_dir = (ProcessingTask & key).fetch1('processing_output_dir')
         output_dir = find_full_path(get_imaging_root_data_dir(), output_dir).as_posix()
         if not output_dir:
             output_dir = ProcessingTask.infer_output_dir(key, relative=True, mkdir=True)
@@ -210,15 +209,15 @@ class Processing(dj.Computed):
             
             method = (ProcessingTask * ProcessingParamSet * ProcessingMethod * scan.Scan & key).fetch1('processing_method')
 
+            image_files = (ProcessingTask * scan.Scan * scan.ScanInfo * scan.ScanInfo.ScanFile & key).fetch('file_path')
+            image_files = [find_full_path(get_imaging_root_data_dir(), image_file) for image_file in image_files]
+
             if method == 'suite2p':
                 import suite2p
 
                 suite2p_params = (ProcessingTask * ProcessingParamSet & key).fetch1('params')
                 suite2p_params['save_path0'] = output_dir
                 suite2p_params['fs'] = (ProcessingTask * scan.Scan * scan.ScanInfo & key).fetch1('fps')
-
-                image_files = (ProcessingTask * scan.Scan * scan.ScanInfo * scan.ScanInfo.ScanFile & key).fetch('file_path')
-                image_files = [find_full_path(get_imaging_root_data_dir(), image_file) for image_file in image_files]
 
                 input_format = pathlib.Path(image_files[0]).suffix
                 suite2p_params['input_format'] = input_format[1:]
@@ -237,9 +236,6 @@ class Processing(dj.Computed):
             elif method == 'caiman':
                 from element_interface.run_caiman import run_caiman
 
-                tiff_files = (ProcessingTask * scan.Scan * scan.ScanInfo * scan.ScanInfo.ScanFile & key).fetch('file_path')
-                tiff_files = [find_full_path(get_imaging_root_data_dir(), tiff_file).as_posix() for tiff_file in tiff_files]
-
                 params = (ProcessingTask * ProcessingParamSet & key).fetch1('params')
                 sampling_rate = (ProcessingTask * scan.Scan * scan.ScanInfo & key).fetch1('fps')
 
@@ -248,7 +244,9 @@ class Processing(dj.Computed):
                 is3D = bool(ndepths > 1)
                 if is3D:
                     raise NotImplementedError('Caiman pipeline is not capable of analyzing 3D scans at the moment.')
-                run_caiman(file_paths=tiff_files, parameters=params, sampling_rate=sampling_rate, output_dir=output_dir, is3D=is3D)
+                run_caiman(file_paths=[f.as_posix() for f in image_files],
+                           parameters=params, sampling_rate=sampling_rate,
+                           output_dir=output_dir, is3D=is3D)
 
                 _, imaging_dataset = get_loader_result(key, ProcessingTask)
                 caiman_dataset = imaging_dataset

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -737,6 +737,39 @@ class ActivityExtractionMethod(dj.Lookup):
 
 
 @schema
+class ActivityExtractionParamSet(dj.Lookup):
+    definition = """  #  Activity extraction parameter set used for the analysis/extraction of calcium events
+    activity_extraction_paramset_idx:  smallint
+    ---
+    -> ActivityExtractionMethod
+    paramset_desc: varchar(128)
+    param_set_hash: uuid
+    unique index (param_set_hash)
+    params: longblob  # dictionary of all applicable parameters
+    """
+
+    @classmethod
+    def insert_new_params(cls, extraction_method: str, activity_paramset_idx: int,
+                          paramset_desc: str, params: dict):
+        param_dict = {'processing_method': extraction_method,
+                      'paramset_idx': activity_paramset_idx,
+                      'paramset_desc': paramset_desc,
+                      'params': params,
+                      'param_set_hash': dict_to_uuid(params)}
+        q_param = cls & {'param_set_hash': param_dict['param_set_hash']}
+
+        if q_param:  # If the specified param-set already exists
+            pname = q_param.fetch1('activity_paramset_idx')
+            if pname == activity_paramset_idx:  # If the existed set has the same name: job done
+                return
+            else:  # If not same name: human error, trying to add the same paramset with different name
+                raise dj.DataJointError(
+                    'The specified param-set already exists - name: {}'.format(pname))
+        else:
+            cls.insert1(param_dict)
+
+
+@schema
 class Activity(dj.Computed):
     definition = """  # inferred neural activity from fluorescence trace - e.g. dff, spikes
     -> Fluorescence

--- a/element_calcium_imaging/scan.py
+++ b/element_calcium_imaging/scan.py
@@ -203,15 +203,6 @@ class ScanInfo(dj.Imported):
         file_path: varchar(255)  # filepath relative to root data directory
         """
 
-    @staticmethod
-    def estimate_scan_duration(scan_obj):
-        # Calculates scan duration for Nikon images
-        ti = scan_obj.frame_metadata(0).channels[0].time.absoluteJulianDayNumber  # Initial frame's JD.
-        tf = scan_obj.frame_metadata(scan_obj.shape[0]-1).channels[0].time.absoluteJulianDayNumber  # Final frame's JD.
-        fps = 1000 / scan_obj.experiment[0].parameters.periods[0].periodDiff.avg  # Frame per second
-        return (tf - ti) * 86400 + 1 / fps
-
-
     def make(self, key):
         acq_software = (Scan & key).fetch1('acq_software')
 
@@ -324,6 +315,17 @@ class ScanInfo(dj.Imported):
             nd2_file = nd2.ND2File(scan_filepaths[0])
             is_multiROI = False  # MultiROI to be implemented later
 
+            # Estimate ND2 file scan duration
+            def estimate_nd2_scan_duration(nd2_scan_obj):
+                # Calculates scan duration for Nikon images
+                ti = nd2_scan_obj.frame_metadata(0).channels[0].time.absoluteJulianDayNumber  # Initial frame's JD.
+                tf = nd2_scan_obj.frame_metadata(nd2_scan_obj.shape[0] - 1).channels[
+                    0].time.absoluteJulianDayNumber  # Final frame's JD.
+                fps = 1000 / nd2_scan_obj.experiment[0].parameters.periods[0].periodDiff.avg  # Frame per second
+                return (tf - ti) * 86400 + 1 / fps
+
+            scan_duration = sum([estimate_nd2_scan_duration(nd2.ND2File(f)) for f in scan_filepaths])
+
             # Insert in ScanInfo
             self.insert1(dict(key,
                               nfields=nd2_file.sizes.get('P', 1),
@@ -336,7 +338,7 @@ class ScanInfo(dj.Imported):
                               fps=1000 / nd2_file.experiment[0].parameters.periods[0].periodDiff.avg,
                               bidirectional=bool(nd2_file.custom_data['GrabberCameraSettingsV1_0']['GrabberCameraSettings']['PropertiesQuality']['ScanDirection']),
                               nrois=0,
-                              scan_duration=self.estimate_scan_duration(nd2_file)))
+                              scan_duration=scan_duration))
 
             # MultiROI to be implemented later
 


### PR DESCRIPTION
Add another parameter table: `ActivityExtractionParamSet` 
So we can parameterize the `Activity` computation

Two points to note:
+ This does change the pipeline design, creating backward compatibility issue
+ If merged, a corresponding update to the test suite in `workflow-calcium-imaging` is needed