### PR TITLE
scan duration estimations

### DIFF
--- a/element_calcium_imaging/scan.py
+++ b/element_calcium_imaging/scan.py
@@ -301,7 +301,7 @@ class ScanInfo(dj.Imported):
                               fps=sbx_meta['frame_rate'],
                               bidirectional=sbx_meta == 'bidirectional',
                               nrois=sbx_meta['num_rois'] if is_multiROI else 0),
-                              scan_duration=(sbx_meta['num_frames'] + 1) / sbx_meta['frame_rate'])
+                              scan_duration=sbx_meta['num_frames'] / sbx_meta['frame_rate'])
             # Insert Field(s)
             if not is_multiROI:
                 px_width, px_height = sbx_meta['frame_size']

--- a/element_calcium_imaging/scan.py
+++ b/element_calcium_imaging/scan.py
@@ -241,7 +241,7 @@ class ScanInfo(dj.Imported):
                               usecs_per_line=scan.seconds_per_line * 1e6,
                               fill_fraction=scan.temporal_fill_fraction,
                               nrois=scan.num_rois if scan.is_multiROI else 0,
-                              scan_duration=(scan.num_frames + 1) / scan.fps))
+                              scan_duration=scan.num_frames / scan.fps))
             # Insert Field(s)
             if scan.is_multiROI:
                 self.Field.insert([

--- a/element_calcium_imaging/scan.py
+++ b/element_calcium_imaging/scan.py
@@ -235,7 +235,7 @@ class ScanInfo(dj.Imported):
                               usecs_per_line=scan.seconds_per_line * 1e6,
                               fill_fraction=scan.temporal_fill_fraction,
                               nrois=scan.num_rois if scan.is_multiROI else 0,
-                              scan_duration=scan.num_frames / scan.fps))
+                              scan_duration=(scan.num_frames + 1) / scan.fps))
             # Insert Field(s)
             if scan.is_multiROI:
                 self.Field.insert([
@@ -294,7 +294,7 @@ class ScanInfo(dj.Imported):
                               fps=sbx_meta['frame_rate'],
                               bidirectional=sbx_meta == 'bidirectional',
                               nrois=sbx_meta['num_rois'] if is_multiROI else 0),
-                              scan_duration=(sbx_meta['num_frames'] + 1)/sbx_meta['frame_rate'])
+                              scan_duration=(sbx_meta['num_frames'] + 1) / sbx_meta['frame_rate'])
             # Insert Field(s)
             if not is_multiROI:
                 px_width, px_height = sbx_meta['frame_size']

--- a/element_calcium_imaging/scan.py
+++ b/element_calcium_imaging/scan.py
@@ -220,8 +220,6 @@ class ScanInfo(dj.Imported):
             z_zero = scan.motor_position_at_zero[2] \
                         if scan.motor_position_at_zero else None
             
-
-
             self.insert1(dict(key,
                               nfields=scan.num_fields,
                               nchannels=scan.num_channels,

--- a/element_calcium_imaging/scan.py
+++ b/element_calcium_imaging/scan.py
@@ -2,8 +2,6 @@ import datajoint as dj
 import pathlib
 import importlib
 import inspect
-import scanreader
-import nd2
 from element_interface.utils import find_root_directory, find_full_path
 
 schema = dj.schema()

--- a/element_calcium_imaging/scan.py
+++ b/element_calcium_imaging/scan.py
@@ -205,6 +205,7 @@ class ScanInfo(dj.Imported):
 
     @staticmethod
     def estimate_scan_duration(scan_obj):
+        # Calculates scan duration for Nikon images
         ti = scan_obj.frame_metadata(0).channels[0].time.absoluteJulianDayNumber  # Initial frame's JD.
         tf = scan_obj.frame_metadata(scan_obj.shape[0]-1).channels[0].time.absoluteJulianDayNumber  # Final frame's JD.
         fps = 1000 / scan_obj.experiment[0].parameters.periods[0].periodDiff.avg  # Frame per second


### PR DESCRIPTION
Method for each file type:

`Scanimage:` Timestamps are in a complicated metadata string, not straightforward to extract. Using the nframes and fps.

`Scanbox:` Can't find the timestamps. Using the nframes and fps.

`NIS:` Found the timestamps and used them to calculate the scan duration.