### PR TITLE
Error fix in `ScanInfo` for PrairieView scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.5.2] - Unreleased
++ Bugfix - fix errors in ingesting single-plane PrairieView scans into `ScanInfo`
+
 ## [0.5.1] - 2022-12-15
 + Add - Imports for prairieview loader
 

--- a/element_calcium_imaging/scan.py
+++ b/element_calcium_imaging/scan.py
@@ -584,79 +584,54 @@ class ScanInfo(dj.Imported):
 
             scan_filepaths = get_prairieview_files(key)
             pvscan_info = prairieviewreader.get_pv_metadata(scan_filepaths[0])
-            if pvscan_info["num_planes"] != 1:
-                self.insert1(
+            self.insert1(
+                dict(
+                    key,
+                    nfields=pvscan_info["num_fields"],
+                    nchannels=pvscan_info["num_channels"],
+                    ndepths=pvscan_info["num_planes"],
+                    nframes=pvscan_info["num_frames"],
+                    nrois=pvscan_info["num_rois"],
+                    x=pvscan_info["x_pos"],
+                    y=pvscan_info["y_pos"],
+                    z=pvscan_info["z_pos"],
+                    fps=pvscan_info["frame_rate"],
+                    bidirectional=pvscan_info["bidirectional"],
+                    bidirectional_z=pvscan_info["bidirectional_z"],
+                    usecs_per_line=pvscan_info["usecs_per_line"],
+                    scan_datetime=pvscan_info["scan_datetime"],
+                    scan_duration=pvscan_info["scan_duration"],
+                )
+            )
+
+            self.Field.insert(
+                [
                     dict(
                         key,
-                        nfields=pvscan_info["num_fields"],
-                        nchannels=pvscan_info["num_channels"],
-                        ndepths=pvscan_info["num_planes"],
-                        nframes=pvscan_info["num_frames"],
-                        nrois=pvscan_info["num_rois"],
-                        x=pvscan_info["x_pos"],
-                        y=pvscan_info["y_pos"],
-                        z=pvscan_info["z_pos"],
-                        fps=pvscan_info["frame_rate"],
-                        bidirectional=pvscan_info["bidirectional"],
-                        bidirectional_z=pvscan_info["bidirectional_z"],
-                        usecs_per_line=pvscan_info["usecs_per_line"],
-                        scan_datetime=pvscan_info["scan_datetime"],
-                        scan_duration=pvscan_info["scan_duration"],
+                        field_idx=0,
+                        px_height=pvscan_info["height_in_pixels"],
+                        px_width=pvscan_info["width_in_pixels"],
+                        um_height=pvscan_info["height_in_um"],
+                        um_width=pvscan_info["width_in_um"],
+                        field_x=pvscan_info["fieldX"],
+                        field_y=pvscan_info["fieldY"],
+                        field_z=pvscan_info["fieldZ"],
                     )
-                )
-
-                self.Field.insert(
-                    [
-                        dict(
-                            key,
-                            field_idx=plane_index,
-                            px_height=pvscan_info["height_in_pixels"],
-                            px_width=pvscan_info["width_in_pixels"],
-                            um_height=pvscan_info["height_in_um"],
-                            um_width=pvscan_info["width_in_um"],
-                            field_x=pvscan_info["fieldX"],
-                            field_y=pvscan_info["fieldY"],
-                            field_z=pvscan_info["fieldZ"][plane_index],
-                        )
-                        for plane_index in range(pvscan_info["num_planes"])
-                    ]
-                )
-            elif pvscan_info["num_planes"] == 1:
-                self.insert1(
-                    dict(
+                    if pvscan_info["num_planes"] == 1
+                    else dict(
                         key,
-                        nfields=pvscan_info["num_fields"],
-                        nchannels=pvscan_info["num_channels"],
-                        ndepths=pvscan_info["num_planes"],
-                        nframes=pvscan_info["num_frames"],
-                        nrois=pvscan_info["num_rois"],
-                        x=pvscan_info["x_pos"],
-                        y=pvscan_info["y_pos"],
-                        z=pvscan_info["z_pos"],
-                        fps=pvscan_info["frame_rate"],
-                        bidirectional=pvscan_info["bidirectional"],
-                        bidirectional_z=pvscan_info["bidirectional_z"],
-                        usecs_per_line=pvscan_info["usecs_per_line"],
-                        scan_datetime=pvscan_info["scan_datetime"],
-                        scan_duration=pvscan_info["scan_duration"],
+                        field_idx=plane_idx,
+                        px_height=pvscan_info["height_in_pixels"],
+                        px_width=pvscan_info["width_in_pixels"],
+                        um_height=pvscan_info["height_in_um"],
+                        um_width=pvscan_info["width_in_um"],
+                        field_x=pvscan_info["fieldX"],
+                        field_y=pvscan_info["fieldY"],
+                        field_z=pvscan_info["fieldZ"][plane_idx],
                     )
-                )
-
-                self.Field.insert(
-                    [
-                        dict(
-                            key,
-                            field_idx=0,
-                            px_height=pvscan_info["height_in_pixels"],
-                            px_width=pvscan_info["width_in_pixels"],
-                            um_height=pvscan_info["height_in_um"],
-                            um_width=pvscan_info["width_in_um"],
-                            field_x=pvscan_info["fieldX"],
-                            field_y=pvscan_info["fieldY"],
-                            field_z=pvscan_info["fieldZ"],
-                        )
-                    ]
-                )
+                    for plane_idx in range(pvscan_info["num_planes"])
+                ]
+            )
         else:
             raise NotImplementedError(
                 f"Loading routine not implemented for {acq_software} "

--- a/element_calcium_imaging/scan.py
+++ b/element_calcium_imaging/scan.py
@@ -14,7 +14,11 @@ _linking_module = None
 
 
 def activate(
-    scan_schema_name, *, create_schema=True, create_tables=True, linking_module=None
+    scan_schema_name,
+    *,
+    create_schema=True,
+    create_tables=True,
+    linking_module=None,
 ):
     """Activate this schema.
 
@@ -330,13 +334,19 @@ class ScanInfo(dj.Imported):
 
             # Insert in ScanInfo
             x_zero = (
-                scan.motor_position_at_zero[0] if scan.motor_position_at_zero else None
+                scan.motor_position_at_zero[0]
+                if scan.motor_position_at_zero
+                else None
             )
             y_zero = (
-                scan.motor_position_at_zero[1] if scan.motor_position_at_zero else None
+                scan.motor_position_at_zero[1]
+                if scan.motor_position_at_zero
+                else None
             )
             z_zero = (
-                scan.motor_position_at_zero[2] if scan.motor_position_at_zero else None
+                scan.motor_position_at_zero[2]
+                if scan.motor_position_at_zero
+                else None
             )
 
             self.insert1(
@@ -393,8 +403,12 @@ class ScanInfo(dj.Imported):
                             field_idx=plane_idx,
                             px_height=scan.image_height,
                             px_width=scan.image_width,
-                            um_height=getattr(scan, "image_height_in_microns", None),
-                            um_width=getattr(scan, "image_width_in_microns", None),
+                            um_height=getattr(
+                                scan, "image_height_in_microns", None
+                            ),
+                            um_width=getattr(
+                                scan, "image_width_in_microns", None
+                            ),
                             field_x=x_zero if x_zero else None,
                             field_y=y_zero if y_zero else None,
                             field_z=z_zero + scan.scanning_depths[plane_idx]
@@ -438,7 +452,9 @@ class ScanInfo(dj.Imported):
                     fps=sbx_meta["frame_rate"],
                     bidirectional=sbx_meta == "bidirectional",
                     nrois=sbx_meta["num_rois"] if is_multiROI else 0,
-                    scan_duration=(sbx_meta["num_frames"] / sbx_meta["frame_rate"]),
+                    scan_duration=(
+                        sbx_meta["num_frames"] / sbx_meta["frame_rate"]
+                    ),
                 )
             )
             # Insert Field(s)
@@ -474,7 +490,12 @@ class ScanInfo(dj.Imported):
 
             # Frame per second
             try:
-                fps = 1000 / nd2_file.experiment[0].parameters.periods[0].periodDiff.avg
+                fps = (
+                    1000
+                    / nd2_file.experiment[0]
+                    .parameters.periods[0]
+                    .periodDiff.avg
+                )
             except:
                 fps = 1000 / nd2_file.experiment[0].parameters.periodDiff.avg
 
@@ -495,7 +516,8 @@ class ScanInfo(dj.Imported):
                 return (tf - ti) * 86400 + 1 / fps
 
             scan_duration = sum(
-                estimate_nd2_scan_duration(nd2.ND2File(f)) for f in scan_filepaths
+                estimate_nd2_scan_duration(nd2.ND2File(f))
+                for f in scan_filepaths
             )
 
             try:
@@ -506,7 +528,9 @@ class ScanInfo(dj.Imported):
                     if re.search(("AM|PM"), scan_datetime)
                     else "%m/%d/%Y %H:%M:%S",
                 )
-                scan_datetime = datetime.strftime(scan_datetime, "%Y-%m-%d %H:%M:%S")
+                scan_datetime = datetime.strftime(
+                    scan_datetime, "%Y-%m-%d %H:%M:%S"
+                )
             except:
                 scan_datetime = None
 
@@ -560,40 +584,75 @@ class ScanInfo(dj.Imported):
 
             scan_filepaths = get_prairieview_files(key)
             pvscan_info = prairieviewreader.get_pv_metadata(scan_filepaths[0])
-            self.insert1(
-                dict(
-                    key,
-                    nfields=pvscan_info["num_fields"],
-                    nchannels=pvscan_info["num_channels"],
-                    ndepths=pvscan_info["num_planes"],
-                    nframes=pvscan_info["num_frames"],
-                    nrois=pvscan_info["num_rois"],
-                    x=pvscan_info["x_pos"],
-                    y=pvscan_info["y_pos"],
-                    z=pvscan_info["z_pos"],
-                    fps=pvscan_info["frame_rate"],
-                    bidirectional=pvscan_info["bidirectional"],
-                    bidirectional_z=pvscan_info["bidirectional_z"],
-                    usecs_per_line=pvscan_info["usecs_per_line"],
-                    scan_datetime=pvscan_info["scan_datetime"],
-                    scan_duration=pvscan_info["scan_duration"],
+            if pvscan_info["num_planes"] != 1:
+                self.insert1(
+                    dict(
+                        key,
+                        nfields=pvscan_info["num_fields"],
+                        nchannels=pvscan_info["num_channels"],
+                        ndepths=pvscan_info["num_planes"],
+                        nframes=pvscan_info["num_frames"],
+                        nrois=pvscan_info["num_rois"],
+                        x=pvscan_info["x_pos"],
+                        y=pvscan_info["y_pos"],
+                        z=pvscan_info["z_pos"],
+                        fps=pvscan_info["frame_rate"],
+                        bidirectional=pvscan_info["bidirectional"],
+                        bidirectional_z=pvscan_info["bidirectional_z"],
+                        usecs_per_line=pvscan_info["usecs_per_line"],
+                        scan_datetime=pvscan_info["scan_datetime"],
+                        scan_duration=pvscan_info["scan_duration"],
+                    )
                 )
-            )
 
-            self.Field.insert(
-                dict(
-                    key,
-                    field_idx=plane_idx,
-                    px_height=pvscan_info["height_in_pixels"],
-                    px_width=pvscan_info["width_in_pixels"],
-                    um_height=pvscan_info["height_in_um"],
-                    um_width=pvscan_info["width_in_um"],
-                    field_x=pvscan_info["fieldX"],
-                    field_y=pvscan_info["fieldY"],
-                    field_z=pvscan_info["fieldZ"][plane_idx],
+                self.Field.insert(
+                    dict(
+                        key,
+                        field_idx=plane_index,
+                        px_height=pvscan_info["height_in_pixels"],
+                        px_width=pvscan_info["width_in_pixels"],
+                        um_height=pvscan_info["height_in_um"],
+                        um_width=pvscan_info["width_in_um"],
+                        field_x=pvscan_info["fieldX"],
+                        field_y=pvscan_info["fieldY"],
+                        field_z=pvscan_info["fieldZ"][plane_index],
+                    )
+                    for plane_index in range(pvscan_info["num_planes"])
                 )
-                for plane_idx in range(pvscan_info["num_planes"])
-            )
+            elif pvscan_info["num_planes"] == 1:
+                self.insert1(
+                    dict(
+                        key,
+                        nfields=pvscan_info["num_fields"],
+                        nchannels=pvscan_info["num_channels"],
+                        ndepths=pvscan_info["num_planes"],
+                        nframes=pvscan_info["num_frames"],
+                        nrois=pvscan_info["num_rois"],
+                        x=pvscan_info["x_pos"],
+                        y=pvscan_info["y_pos"],
+                        z=pvscan_info["z_pos"],
+                        fps=pvscan_info["frame_rate"],
+                        bidirectional=pvscan_info["bidirectional"],
+                        bidirectional_z=pvscan_info["bidirectional_z"],
+                        usecs_per_line=pvscan_info["usecs_per_line"],
+                        scan_datetime=pvscan_info["scan_datetime"],
+                        scan_duration=pvscan_info["scan_duration"],
+                    )
+                )
+
+                self.Field.insert(
+                    dict(
+                        key,
+                        field_idx=0,
+                        px_height=pvscan_info["height_in_pixels"],
+                        px_width=pvscan_info["width_in_pixels"],
+                        um_height=pvscan_info["height_in_um"],
+                        um_width=pvscan_info["width_in_um"],
+                        field_x=pvscan_info["fieldX"],
+                        field_y=pvscan_info["fieldY"],
+                        field_z=pvscan_info["fieldZ"],
+                    )
+                )
         else:
             raise NotImplementedError(
                 f"Loading routine not implemented for {acq_software} "
@@ -601,9 +660,12 @@ class ScanInfo(dj.Imported):
             )
 
         # Insert file(s)
-        root_dir = find_root_directory(get_imaging_root_data_dir(), scan_filepaths[0])
+        root_dir = find_root_directory(
+            get_imaging_root_data_dir(), scan_filepaths[0]
+        )
 
         scan_files = [
-            pathlib.Path(f).relative_to(root_dir).as_posix() for f in scan_filepaths
+            pathlib.Path(f).relative_to(root_dir).as_posix()
+            for f in scan_filepaths
         ]
         self.ScanFile.insert([{**key, "file_path": f} for f in scan_files])

--- a/element_calcium_imaging/scan.py
+++ b/element_calcium_imaging/scan.py
@@ -605,20 +605,7 @@ class ScanInfo(dj.Imported):
             )
 
             self.Field.insert(
-                [
                     dict(
-                        key,
-                        field_idx=0,
-                        px_height=pvscan_info["height_in_pixels"],
-                        px_width=pvscan_info["width_in_pixels"],
-                        um_height=pvscan_info["height_in_um"],
-                        um_width=pvscan_info["width_in_um"],
-                        field_x=pvscan_info["fieldX"],
-                        field_y=pvscan_info["fieldY"],
-                        field_z=pvscan_info["fieldZ"],
-                    )
-                    if pvscan_info["num_planes"] == 1
-                    else dict(
                         key,
                         field_idx=plane_idx,
                         px_height=pvscan_info["height_in_pixels"],
@@ -627,10 +614,9 @@ class ScanInfo(dj.Imported):
                         um_width=pvscan_info["width_in_um"],
                         field_x=pvscan_info["fieldX"],
                         field_y=pvscan_info["fieldY"],
-                        field_z=pvscan_info["fieldZ"][plane_idx],
+                        field_z=pvscan_info["fieldZ"] if pvscan_info["num_planes"] == 1 else pvscan_info["fieldZ"][plane_idx],
                     )
                     for plane_idx in range(pvscan_info["num_planes"])
-                ]
             )
         else:
             raise NotImplementedError(

--- a/element_calcium_imaging/scan.py
+++ b/element_calcium_imaging/scan.py
@@ -606,18 +606,20 @@ class ScanInfo(dj.Imported):
                 )
 
                 self.Field.insert(
-                    dict(
-                        key,
-                        field_idx=plane_index,
-                        px_height=pvscan_info["height_in_pixels"],
-                        px_width=pvscan_info["width_in_pixels"],
-                        um_height=pvscan_info["height_in_um"],
-                        um_width=pvscan_info["width_in_um"],
-                        field_x=pvscan_info["fieldX"],
-                        field_y=pvscan_info["fieldY"],
-                        field_z=pvscan_info["fieldZ"][plane_index],
-                    )
-                    for plane_index in range(pvscan_info["num_planes"])
+                    [
+                        dict(
+                            key,
+                            field_idx=plane_index,
+                            px_height=pvscan_info["height_in_pixels"],
+                            px_width=pvscan_info["width_in_pixels"],
+                            um_height=pvscan_info["height_in_um"],
+                            um_width=pvscan_info["width_in_um"],
+                            field_x=pvscan_info["fieldX"],
+                            field_y=pvscan_info["fieldY"],
+                            field_z=pvscan_info["fieldZ"][plane_index],
+                        )
+                        for plane_index in range(pvscan_info["num_planes"])
+                    ]
                 )
             elif pvscan_info["num_planes"] == 1:
                 self.insert1(
@@ -641,17 +643,19 @@ class ScanInfo(dj.Imported):
                 )
 
                 self.Field.insert(
-                    dict(
-                        key,
-                        field_idx=0,
-                        px_height=pvscan_info["height_in_pixels"],
-                        px_width=pvscan_info["width_in_pixels"],
-                        um_height=pvscan_info["height_in_um"],
-                        um_width=pvscan_info["width_in_um"],
-                        field_x=pvscan_info["fieldX"],
-                        field_y=pvscan_info["fieldY"],
-                        field_z=pvscan_info["fieldZ"],
-                    )
+                    [
+                        dict(
+                            key,
+                            field_idx=0,
+                            px_height=pvscan_info["height_in_pixels"],
+                            px_width=pvscan_info["width_in_pixels"],
+                            um_height=pvscan_info["height_in_um"],
+                            um_width=pvscan_info["width_in_um"],
+                            field_x=pvscan_info["fieldX"],
+                            field_y=pvscan_info["fieldY"],
+                            field_z=pvscan_info["fieldZ"],
+                        )
+                    ]
                 )
         else:
             raise NotImplementedError(

--- a/element_calcium_imaging/version.py
+++ b/element_calcium_imaging/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.5.1"
+__version__ = "0.5.2"


### PR DESCRIPTION
**PR HIGHLIGHTS:**
This PR specifically addresses ingestion of single-plane scans into the ScanInfo table using the PrairieView loader. The existing codebase assumes the number of planes acquired is always > 1. I've added an `if - elif` statement between lines `587-655`. 

- [x] The code was tested locally on one image and `ScanInfo` was successfully populated. 
- [x] The code was formatted using Black. 
- [x] CHANGELOG and version.py updated

**PR DETAILS:**
Current code in `scan.py` results in the following error when attempting to populate `ScanInfo` and this PR will catch and prevent this from occurring. 
```In [18]: scan.ScanInfo.populate()
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
Input In [18], in <cell line: 1>()
----> 1 scan.ScanInfo.populate()

File /opt/conda/lib/python3.9/site-packages/datajoint/autopopulate.py:230, in AutoPopulate.populate(self, suppress_errors, return_exception_objects, reserve_jobs, order, limit, max_calls, display_progress, processes, make_kwargs, *restrictions)
    226 if processes == 1:
    227     for key in (
    228         tqdm(keys, desc=self.__class__.__name__) if display_progress else keys
    229     ):
--> 230         error = self._populate1(key, jobs, **populate_kwargs)
    231         if error is not None:
    232             error_list.append(error)

File /opt/conda/lib/python3.9/site-packages/datajoint/autopopulate.py:281, in AutoPopulate._populate1(self, key, jobs, suppress_errors, return_exception_objects, make_kwargs)
    279 self.__class__._allow_insert = True
    280 try:
--> 281     make(dict(key), **(make_kwargs or {}))
    282 except (KeyboardInterrupt, SystemExit, Exception) as error:
    283     try:

File /opt/conda/lib/python3.9/site-packages/element_calcium_imaging/scan.py:583, in ScanInfo.make(self, key)
    562     pvscan_info = prairieviewreader.get_pv_metadata(scan_filepaths[0])
    563     self.insert1(
    564         dict(
    565             key,
   (...)
    580         )
    581     )
--> 583     self.Field.insert(
    584         dict(
    585             key,
    586             field_idx=plane_idx,
    587             px_height=pvscan_info["height_in_pixels"],
    588             px_width=pvscan_info["width_in_pixels"],
    589             um_height=pvscan_info["height_in_um"],
    590             um_width=pvscan_info["width_in_um"],
    591             field_x=pvscan_info["fieldX"],
    592             field_y=pvscan_info["fieldY"],
    593             field_z=pvscan_info["fieldZ"][plane_idx],
    594         )
    595         for plane_idx in range(pvscan_info["num_planes"])
    596     )
    597 else:
    598     raise NotImplementedError(
    599         f"Loading routine not implemented for {acq_software} "
    600         "acquisition software"
    601     )

File /opt/conda/lib/python3.9/site-packages/datajoint/table.py:409, in Table.insert(self, rows, replace, skip_duplicates, ignore_extra_fields, allow_direct_insert)
    406     return
    408 field_list = []  # collects the field list from first row (passed by reference)
--> 409 rows = list(
    410     self.__make_row_to_insert(row, field_list, ignore_extra_fields)
    411     for row in rows
    412 )
    413 if rows:
    414     try:

File /opt/conda/lib/python3.9/site-packages/datajoint/table.py:409, in <genexpr>(.0)
    406     return
    408 field_list = []  # collects the field list from first row (passed by reference)
--> 409 rows = list(
    410     self.__make_row_to_insert(row, field_list, ignore_extra_fields)
    411     for row in rows
    412 )
    413 if rows:
    414     try:

File /opt/conda/lib/python3.9/site-packages/element_calcium_imaging/scan.py:593, in <genexpr>(.0)
    562     pvscan_info = prairieviewreader.get_pv_metadata(scan_filepaths[0])
    563     self.insert1(
    564         dict(
    565             key,
   (...)
    580         )
    581     )
    583     self.Field.insert(
    584         dict(
    585             key,
    586             field_idx=plane_idx,
    587             px_height=pvscan_info["height_in_pixels"],
    588             px_width=pvscan_info["width_in_pixels"],
    589             um_height=pvscan_info["height_in_um"],
    590             um_width=pvscan_info["width_in_um"],
    591             field_x=pvscan_info["fieldX"],
    592             field_y=pvscan_info["fieldY"],
--> 593             field_z=pvscan_info["fieldZ"][plane_idx],
    594         )
    595         for plane_idx in range(pvscan_info["num_planes"])
    596     )
    597 else:
    598     raise NotImplementedError(
    599         f"Loading routine not implemented for {acq_software} "
    600         "acquisition software"
    601     )

IndexError: invalid index to scalar variable.```