### PR TITLE
Rearrange requirements installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
-## [0.5.2] - Unreleased
+
+## [0.5.2] - 2023-01-11
 + Bugfix - fix errors in ingesting single-plane PrairieView scans into `ScanInfo`
++ Add - Optional installation of caiman and suite2p through pip
 
 ## [0.5.1] - 2022-12-15
 + Add - Imports for prairieview loader

--- a/element_calcium_imaging/version.py
+++ b/element_calcium_imaging/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.5.2"
+__version__ = "0.5.3"

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,14 @@ with open(path.join(here, pkg_name, "version.py")) as f:
 subprocess.call(["pip", "install", "numpy", "Cython"])
 
 extras_require = {
-    "suite2p": ["suite2p @ git+https://github.com/datajoint-company/suite2p.git"],
-    "caiman": ["caiman @ git+https://github.com/datajoint-company/CaImAn.git"],
+    "suite2p": "suite2p @ git+https://github.com/datajoint-company/suite2p.git",
+    "caiman": "caiman @ git+https://github.com/datajoint-company/CaImAn.git",
+    "readers": [
+        "nd2==0.1.6",
+        "tifffile==2021.11.2",
+        "sbxreader==0.1.6.post1",
+        "scanreader @ git+https://github.com/atlab/scanreader.git",
+    ],
 }
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,42 @@
 #!/usr/bin/env python
-from setuptools import setup, find_packages
+import subprocess
 from os import path
+from setuptools import setup, find_packages
 
-pkg_name = next(p for p in find_packages() if '.' not in p)
+
+pkg_name = next(p for p in find_packages() if "." not in p)
 here = path.abspath(path.dirname(__file__))
 
-with open(path.join(here, 'README.md'), 'r') as f:
+with open(path.join(here, "README.md"), "r") as f:
     long_description = f.read()
 
-with open(path.join(here, 'requirements.txt')) as f:
+with open(path.join(here, "requirements.txt")) as f:
     requirements = f.read().splitlines()
 
-with open(path.join(here, pkg_name, 'version.py')) as f:
+with open(path.join(here, pkg_name, "version.py")) as f:
     exec(f.read())
 
+# Prerequisite of caiman installation to run its setup.py
+subprocess.call(["pip", "install", "numpy", "Cython"])
+
+extras_require = {
+    "suite2p": ["suite2p @ git+https://github.com/datajoint-company/suite2p.git"],
+    "caiman": ["caiman @ git+https://github.com/datajoint-company/CaImAn.git"],
+}
+
 setup(
-    name=pkg_name.replace('_', '-'),
+    name=pkg_name.replace("_", "-"),
     version=__version__,
     description="Calcium Imaging DataJoint element",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    author='DataJoint',
-    author_email='info@datajoint.com',
-    license='MIT',
+    long_description_content_type="text/markdown",
+    author="DataJoint",
+    author_email="info@datajoint.com",
+    license="MIT",
     url=f'https://github.com/datajoint/{pkg_name.replace("_", "-")}',
-    keywords='neuroscience calcium-imaging science datajoint',
-    packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
+    keywords="neuroscience calcium-imaging science datajoint",
+    packages=find_packages(exclude=["contrib", "docs", "tests*"]),
     scripts=[],
     install_requires=requirements,
+    extras_require=extras_require,
 )


### PR DESCRIPTION
Caiman's `setup.py` imports `numpy` and `Cython`. If these packages are not available at the time of installing caiman, caiman installation will fail dramatically. So, these packages need to be installed before caiman installation. To fix the problem, this PR installs these packages within `element-calcium-imaging`'s `setup.py file`. With this change, caiman is now installable through `extra_requires`.


To install `caiman` optionally:
```python
pip install "element-calcium-imaging[caiman]"
```

To install `suite2p` optionally:
```python
pip install "element-calcium-imaging[suite2p]"
```

To install `caiman` and `suite2p`:
```python
pip install "element-calcium-imaging[caiman, suite2p]"
```

This PR also groups some of the readers to be optionally installable as `readers` in the `extras_require`. Note that these packages are very light; so their collective installation don't blow up the size.

The optional installations are tested sucessfully in an isolated conda environment as well as in `workflow-calcium-imaging`'s Dockerfile.