### PR TITLE
Add requirement for `ipywidgets`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.5.4] - 2023-03-08
+
++ Add - Requirement for `ipywidgets`
+
 ## [0.5.3] - 2023-02-23
 
 + Add - spelling, markdown, and pre-commit config files
@@ -79,6 +83,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 + Add - `scan` and `imaging` modules
 + Add - Readers for `ScanImage`, `ScanBox`, `Suite2p`, `CaImAn`
 
+[0.5.4]: https://github.com/datajoint/element-calcium-imaging/releases/tag/0.5.4
 [0.5.3]: https://github.com/datajoint/element-calcium-imaging/releases/tag/0.5.3
 [0.5.2]: https://github.com/datajoint/element-calcium-imaging/releases/tag/0.5.2
 [0.5.1]: https://github.com/datajoint/element-calcium-imaging/releases/tag/0.5.1

--- a/element_calcium_imaging/version.py
+++ b/element_calcium_imaging/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.5.3"
+__version__ = "0.5.4"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 datajoint>=0.13.0
 element-interface>=0.4.0
 plotly
+ipywidgets


### PR DESCRIPTION
This PR adds `ipywidgets` to requirements.txt. This will ensure the visualization widget runs with `workflow-calcium-imaging` on GitHub CodeSpaces without resulting in a missing package error. 

- [x] Add to requirements.txt
- [x] Update CHANGELOG
- [x] Update version.py