### PR TITLE
Fix bug with docs release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 ## [0.5.4] - 2023-03-08
 
 + Add - Requirement for `ipywidgets`
++ Update - Docker Compose file for docs release
 
 ## [0.5.3] - 2023-02-23
 

--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -35,8 +35,6 @@ services:
         if [ -d /main/delete/ ]; then
           mv /main/delete/workflow_$${ELEMENT_UNDERSCORE} /main/
           mv /main/delete/notebooks/*ipynb /main/docs/src/tutorials/
-          rm /main/docs/src/tutorials/05*ipynb # CURRENTLY HAS PROBLEMATIC UNICODE STRING
-          rm /main/docs/src/tutorials/2022-allen*ipynb # DUPLICATES OTHER NOTEBOOKS
           rm -fR /main/delete
         fi 
         if echo "$${MODE}" | grep -i live &>/dev/null; then


### PR DESCRIPTION
- Fix to address removal of notebooks from `workflow-calcium-imaging`
- Will trigger a new release of `0.5.4` to publish to PyPI