### PR TITLE
Update version for element-interface requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.5.5] - 2023-04-06
+
++ Update - Bump `element-interface` requirement to `0.5.1`.
+
 ## [0.5.4] - 2023-03-08
 
 + Add - Requirement for `ipywidgets`
@@ -84,6 +88,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 + Add - `scan` and `imaging` modules
 + Add - Readers for `ScanImage`, `ScanBox`, `Suite2p`, `CaImAn`
 
+[0.5.5]: https://github.com/datajoint/element-calcium-imaging/releases/tag/0.5.5
 [0.5.4]: https://github.com/datajoint/element-calcium-imaging/releases/tag/0.5.4
 [0.5.3]: https://github.com/datajoint/element-calcium-imaging/releases/tag/0.5.3
 [0.5.2]: https://github.com/datajoint/element-calcium-imaging/releases/tag/0.5.2

--- a/element_calcium_imaging/version.py
+++ b/element_calcium_imaging/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.5.4"
+__version__ = "0.5.5"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 datajoint>=0.13.0
-element-interface>=0.4.0
+element-interface>=0.5.1
 plotly
 ipywidgets


### PR DESCRIPTION
This PR increases the version requirement for `element-interface` to `0.5.1`. This version fixes an issue with `prairieviewreader.py` mentioned [here](https://github.com/datajoint/element-interface/issues/77). 