### PR TITLE
Fix docs tutorials in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
-## [0.5.6] = 2023=04-28
+## [0.5.6] - 2023-04-28
 
 + Fix - `.ipynb` output in tutorials is not visible in dark mode.
 + Fix - typos in docstrings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.5.6] = 2023=04-28
+
++ Fix - `.ipynb` output in tutorials is not visible in dark mode.
++ Fix - typos in docstrings.
+
 ## [0.5.5] - 2023-04-06
 
 + Update - Bump `element-interface` requirement to `0.5.1`.
@@ -88,6 +93,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 + Add - `scan` and `imaging` modules
 + Add - Readers for `ScanImage`, `ScanBox`, `Suite2p`, `CaImAn`
 
+[0.5.6]: https://github.com/datajoint/element-calcium-imaging/releases/tag/0.5.6
 [0.5.5]: https://github.com/datajoint/element-calcium-imaging/releases/tag/0.5.5
 [0.5.4]: https://github.com/datajoint/element-calcium-imaging/releases/tag/0.5.4
 [0.5.3]: https://github.com/datajoint/element-calcium-imaging/releases/tag/0.5.3

--- a/docs/src/.overrides/assets/stylesheets/extra.css
+++ b/docs/src/.overrides/assets/stylesheets/extra.css
@@ -95,3 +95,7 @@ html a[title="YouTube"].md-social__link svg {
     /* previous/next text */
     /* --md-footer-fg-color: var(--dj-white); */
 }
+
+[data-md-color-scheme="slate"] .jupyter-wrapper .Table Td {
+    color: var(--dj-black)
+}

--- a/docs/src/tutorials/index.md
+++ b/docs/src/tutorials/index.md
@@ -21,7 +21,7 @@ analysis.
 ## Notebooks
 
 Each of the notebooks in the workflow
-([download here](https://github.com/datajoint/workflow-calcium-imaging/tree/main/notebooks)
+[download here](https://github.com/datajoint/workflow-calcium-imaging/tree/main/notebooks)
 steps through ways to interact with the Element itself. For convenience, these notebooks
 are also rendered as part of this site. To try out the notebooks in an online
 Jupyter environment with access to example data, visit

--- a/docs/src/tutorials/index.md
+++ b/docs/src/tutorials/index.md
@@ -21,7 +21,7 @@ analysis.
 ## Notebooks
 
 Each of the notebooks in the workflow
-[download here](https://github.com/datajoint/workflow-calcium-imaging/tree/main/notebooks)
+([download here](https://github.com/datajoint/workflow-calcium-imaging/tree/main/notebooks))
 steps through ways to interact with the Element itself. For convenience, these notebooks
 are also rendered as part of this site. To try out the notebooks in an online
 Jupyter environment with access to example data, visit

--- a/element_calcium_imaging/imaging.py
+++ b/element_calcium_imaging/imaging.py
@@ -201,7 +201,7 @@ class MaskType(dj.Lookup):
     """Available labels for segmented masks (e.g. 'soma', 'axon', 'dendrite', 'neuropil').
 
     Attributes:
-        masky_type (str): Mask type.
+        mask_type (str): Mask type.
     """
 
     definition = """# Possible types of a segmented mask

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -201,7 +201,7 @@ class MaskType(dj.Lookup):
     """Available labels for segmented masks (e.g. 'soma', 'axon', 'dendrite', 'neuropil').
 
     Attributes:
-        masky_type (str): Mask type.
+        mask_type (str): Mask type.
     """
 
     definition = """# Possible types of a segmented mask
@@ -221,8 +221,8 @@ class ProcessingTask(dj.Manual):
     This table defines a calcium imaging processing task for a combination of a
     `Scan` and a `ProcessingParamSet` entries, including all the inputs (scan, method,
     method's parameters). The task defined here is then run in the downstream table
-    Processing. This table supports definitions of both loading of pre-generated results
-    and the triggering of new analysis for all supported analysis methods
+    `Processing`. This table supports definitions of both loading of pre-generated results
+    and the triggering of new analysis for all supported analysis methods.
 
     Attributes:
         scan.Scan (foreign key):

--- a/element_calcium_imaging/imaging_preprocess.py
+++ b/element_calcium_imaging/imaging_preprocess.py
@@ -385,7 +385,7 @@ class MaskType(dj.Lookup):
     """Available labels for segmented masks (e.g. 'soma', 'axon', 'dendrite', 'neuropil').
 
     Attributes:
-        masky_type (str): Mask type.
+        mask_type (str): Mask type.
     """
 
     definition = """# Possible types of a segmented mask

--- a/element_calcium_imaging/version.py
+++ b/element_calcium_imaging/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.5.5"
+__version__ = "0.5.6"


### PR DESCRIPTION
This PR fixes the output of tutorial notebooks when viewed in dark mode within the documentation. 

A few small typos were also corrected here. 

The following tasks are a part of this PR:

- [x] Add docs fix to extra.css.
- [x] Update CHANGELOG.
- [x] Update version.py.
- [ ] Push an updated tag after the PR is merged.