### PR TITLE
Update import statement for prairie_view_loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.7.8] - 2023-07-23
+
++ Update - import statement for `prairie_view_loader` in `scan.py`
+
 ## [0.7.7] - 2023-07-13
 
 + Add - Environment variables for the Python version in the Dev Container
@@ -156,6 +160,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 + Add - `scan` and `imaging` modules
 + Add - Readers for `ScanImage`, `ScanBox`, `Suite2p`, `CaImAn`
 
+[0.7.8]: https://github.com/datajoint/element-calcium-imaging/releases/tag/0.7.8
 [0.7.7]: https://github.com/datajoint/element-calcium-imaging/releases/tag/0.7.7
 [0.7.6]: https://github.com/datajoint/element-calcium-imaging/releases/tag/0.7.6
 [0.7.5]: https://github.com/datajoint/element-calcium-imaging/releases/tag/0.7.5

--- a/element_calcium_imaging/scan.py
+++ b/element_calcium_imaging/scan.py
@@ -517,10 +517,10 @@ class ScanInfo(dj.Imported):
                     ]
                 )
         elif acq_software == "PrairieView":
-            from element_interface import prairieviewreader
+            from element_interface import prairie_view_loader
 
             scan_filepaths = get_image_files(key, "*.tif")
-            PVScan_info = prairieviewreader.get_pv_metadata(scan_filepaths[0])
+            PVScan_info = prairie_view_loader.get_prairieview_metadata(scan_filepaths[0])
             self.insert1(
                 dict(
                     key,

--- a/element_calcium_imaging/version.py
+++ b/element_calcium_imaging/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.7.7"
+__version__ = "0.7.8"


### PR DESCRIPTION
The following tasks have been / will be completed by merging this PR: 

- [ ] Update import statement to reflect recent naming changes in `element_interface/prairie_view_loader.py` v.0.6.0. 
- [ ] Verify that the `ScanInfo` and `ScanInfo.Field` dictionary key / value pairs do not need updating in light of the changes above. 
- [ ] Update CHANGELOG
- [ ] Update version.py
- [ ] Update tag and release to PyPI