### PR TITLE
Add z drift metrics to `imaging.py`

### DIFF
--- a/element_calcium_imaging/scan.py
+++ b/element_calcium_imaging/scan.py
@@ -117,6 +117,17 @@ def get_calcium_imaging_files(scan_key: dict, acq_software: str) -> list:
     return _linking_module.get_calcium_imaging_files(scan_key, acq_software)
 
 
+def get_zstack_files(scan_key: dict) -> list:
+    """Retrieve the list of zstack files associated with a given Scan.
+    Args:
+        scan_key: Primary key of a Scan entry.
+    Returns:
+        A list of zstack files' full file-paths.
+    """
+
+    return _linking_module.get_zstack_files(scan_key)
+
+
 # ----------------------------- Table declarations ----------------------
 
 


### PR DESCRIPTION
This PR adds @dimitri-yatsenko's Z-drift metrics functions. The current version only implements this feature for files acquired from Nikon's NIS acquisition software since that was the only test dataset available at the time of opening this draft PR. Support for other acquisition software will be added as 3D datasets are made available for these systems. 

Tasks to complete before merging: 

- [ ] Finalize schema and `make()` function design
- [ ] Add to the Element documentation
- [ ] Add and update docstrings
- [ ] Update CHANGELOG
- [ ] Update version.py