### PR TITLE
Fix docs - Missing left navigation sidebar

### DIFF
--- a/docs/.docker/pip_requirements.txt
+++ b/docs/.docker/pip_requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material
+mkdocs-material==9.1.17
 mkdocs-redirects
 mkdocstrings
 mkdocstrings-python


### PR DESCRIPTION
## Description

  - Recent versions of `mkdocs-material` have broken the left navigation sidebar.  The table of contents are missing in the image below.

    <img width="1210" alt="image" src="https://github.com/datajoint/element-calcium-imaging/assets/871137/b82c675a-2ff9-4cff-87ef-263ac23a3066">

## Changes

  - By pinning the version of `mkdocs-material` the table of contents are now displayed.  In the future will have to determine why the latest version of `mkdocs-material` causes this bug.

    <img width="1329" alt="image" src="https://github.com/datajoint/element-calcium-imaging/assets/871137/24002fb8-b6c0-413b-87ee-5664ba5ae530">
